### PR TITLE
Add toolchain instructions for Ubuntu 18.04

### DIFF
--- a/InstallToolchainOnUbuntu18-04.md
+++ b/InstallToolchainOnUbuntu18-04.md
@@ -1,0 +1,16 @@
+## Installing the esp32 toolchain on Ubuntu 18.04
+
+These instructions must be followed in order.
+
+1. Download and install the Arduino IDE from Arduino directly [here](https://www.arduino.cc/en/main/software).
+Do not install from the PPA.
+
+2. Add the esp32 board by following [these instructions](https://github.com/espressif/arduino-esp32/blob/master/docs/arduino-ide/boards_manager.md).
+Then in Tools > Board select `ESP32 Dev Module`.
+
+3. Install the libraries according to [these instructions](https://github.com/WPIRoboticsEngineering/RobotInterfaceBoard#which-libraries).
+Make sure to find the correct section for your class (i.e. 1001, 2001, 2002).
+
+4. In a terminal, run `sudo apt install -y python-pip`. After that finishes, run `pip2 install --user pyserial`.
+
+5. You will now be able to compile the template project.

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ C:/RBEArduino/
 
 Ubuntu 18.04 Instructions:
 
-[InstallToolchainOnUbuntu18-04.md](https://github.com/WPIRoboticsEngineering/RobotInterfaceBoard/blob/master/InstallToolchainOnUbuntu18-04.md)
+[InstallToolchainOnUbuntu18-04.md](InstallToolchainOnUbuntu18-04.md)
 
 Ubuntu 16.04 Instructions:
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,11 @@ C:/RBEArduino/
 
 ## Personal Computer install Linux / Mac  (Unsupported)
 
-Linux Instructions (16.04 works well, 18.04 is a bit fiddely and needs extra steps but can be made to work):
+Ubuntu 18.04 Instructions:
+
+[InstallToolchainOnUbuntu18-04.md](https://github.com/WPIRoboticsEngineering/RobotInterfaceBoard/blob/master/InstallToolchainOnUbuntu18-04.md)
+
+Ubuntu 16.04 Instructions:
 
 https://github.com/espressif/arduino-esp32/blob/master/docs/arduino-ide/debian_ubuntu.md
 


### PR DESCRIPTION
This PR adds instructions for how to install the toolchain on Ubuntu 18.04. This was tested in a new VM running Pop!_OS 18.04 (basically Ubuntu).